### PR TITLE
Now Magic exports each step with a different name (#95)

### DIFF
--- a/magic/js/index.js
+++ b/magic/js/index.js
@@ -518,7 +518,7 @@ function exportMagIC() {
           }
       
           magicMeasurements.push([
-            specimen.name + "_" + locationIndex,
+            specimen.name + "_" + locationIndex + "_" + step.step,
             specimen.name + "_" + locationIndex + "_" + demagnetizationType,
             specimen.name,
             experimentCounter++,


### PR DESCRIPTION
* Minor fix Magic

Now it exports properly core_dip in MagIC format (which are coordinates for X and not Z)

* Update index.html

* other MagIC fit